### PR TITLE
Change the platform string for Bigstone-G

### DIFF
--- a/machine/celestica/cel_bigstone_g/rootconf/sysroot-lib-onie/platform-discover
+++ b/machine/celestica/cel_bigstone_g/rootconf/sysroot-lib-onie/platform-discover
@@ -1,26 +1,20 @@
 #
-#	Detect which type of card the Celestica Bigstone_G COM-E is connected to.
-#	Possible return values in the platform variable are:
-#		xxxx = Unknown
-#		lc1l = Left half of a line card
-#		lc1r = Right half of a line card
-#		fab1 = Fabric card
+#	Detect which type of card to which the Celestica Bigstone_G COM-E is
+#	connected. The format of the return value (in the $platform variable)
+#	is:
+#		{Part Number}[_{Label Revision}]
+#	where:
+#		{Part Number} is the Part Number field (0x22) from the EEPROM
+#		{Label Revision} is the Label Revision field (0x27) from the
+#			EEPROM. This field is not present for fabric cards.
 #
 bigstone_g_card_detect()
 {
-	platform="xxxx"
 	local PART_NUM=$(/usr/bin/onie-syseeprom -g 0x22)
-	# Line card?
-	if [ "${PART_NUM}" = "R1110-F0002-01" ] || [ "${PART_NUM}" = "20-001532" ] ; then
-		local LC_SIDE=$(/usr/bin/onie-syseeprom -g 0x27)
-		if [ "${LC_SIDE}" = "LEFT" ] ; then
-			platform="lc1l"
-		elif [ "${LC_SIDE}" = "RIGHT" ] ; then
-			platform="lc1r"
-		fi
-	# Fabric card?
-	elif [ "${PART_NUM}" = "R1110-F0001-01" ] || [ "${PART_NUM}" = "20-001533" ] ; then
-		platform="fab1"
-	fi
+	local LABEL_REV
+	LABEL_REV="_"$(/usr/bin/onie-syseeprom -g 0x27) || LABEL_REV=""
+	platform=$(/bin/echo ${PART_NUM}${LABEL_REV} |
+		   /bin/sed s/-/_/g |
+		   /usr/bin/awk '{print tolower($0)}')
 }
 


### PR DESCRIPTION
The platform string for the Celestica Bigstone-G (aka Facebook Backpack) is
determined by reading the Part Number (0x22) and Label Revision (0x27) fields
from the EEPROM and then using those fields to determine if the platform is
a Fabric Card, Left Line Card, or Right Line Card.

This patch changes the platform string to simply be the values read from the
EEPROM: <part number>[_<label revision>]. The fields are lowercased and hyphens
are converted to underscores. ONIE will no longer be interpreting the EEPROM
contents to determine the platform type. That responsibility is now placed on
the OS installer.

Signed-off-by: Curt Brune <curt@brune.net>